### PR TITLE
US898086: Update logback to 1.4.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.4.14</version>
+                <version>1.5.3</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.4.14</version>
+                <version>1.5.3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,17 +79,17 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-access</artifactId>
-                <version>1.4.11</version>
+                <version>1.4.14</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.4.11</version>
+                <version>1.4.14</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.4.11</version>
+                <version>1.4.14</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=898086

Latest logback version is 1.5.3 but there does not seem to be a 1.5 stream of [logback-access](https://mvnrepository.com/artifact/ch.qos.logback/logback-access) so this PR is moving the 3 dependencies to 1.4.14