### PR TITLE
Update Tomcat to 10.1.31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 **/target/
+.vscode/

--- a/opensuse-tomcat-jre17-juli-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-jre17-juli-image/src/main/docker/Dockerfile
@@ -27,13 +27,13 @@ ENV TOMCAT_ROOT_DIR $TOMCAT_PARENT_DIR/$TOMCAT_DIR_NAME
 ENV TOMCAT_CONF_DIR $TOMCAT_ROOT_DIR/conf
 
 # Download, extract Tomcat and remove unwanted web applications
-RUN curl -fsSL -o /wd/apache-tomcat-10.1.24.tar.gz https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.24/bin/apache-tomcat-10.1.24.tar.gz && \
-    echo 793802f5cbbc0c4f722d3c63b52323df7ca37846445c254edcaaa7702fd71cf72aa9506b2b2c59322b9635e25f69913aa1b223098d9b4f1426f5f5447dd78ff3 \
-        /wd/apache-tomcat-10.1.24.tar.gz | sha512sum -c - && \
+RUN curl -fsSL -o /wd/apache-tomcat-10.1.31.tar.gz https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.31/bin/apache-tomcat-10.1.31.tar.gz && \
+    echo 0e3d423a843e2d9ba4f28a9f0a2f1073d5a1389557dfda041759f8df968bace63cd6948bd76df2727b5133ddb7c33e05dab43cea1d519ca0b6d519461152cce9 \
+        /wd/apache-tomcat-10.1.31.tar.gz | sha512sum -c - && \
     mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-10.1.24.tar.gz && \
-    mv apache-tomcat-10.1.24 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-10.1.31.tar.gz && \
+    mv apache-tomcat-10.1.31 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf docs/ examples/ host-manager/ manager/
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>com.github.tomcat-slf4j-logback</groupId>
                 <artifactId>tomcat10-slf4j-logback</artifactId>
-                <version>10.1.24</version>
+                <version>10.1.31</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -140,7 +140,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-juli</artifactId>
-                <version>10.1.24</version>
+                <version>10.1.31</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/release-notes-2.5.0.md
+++ b/release-notes-2.5.0.md
@@ -5,4 +5,6 @@ ${version-number}
 
 #### New Features
 
+- Update to Tomcat 10.1.31
+
 #### Known Issues


### PR DESCRIPTION
## Overview

This change mitigates a CVE found in Tomcat 10.1.24 by updating to 10.1.31.

## Reference links

- [NVD - CVE-2024-34750](https://nvd.nist.gov/vuln/detail/CVE-2024-34750)