### PR TITLE
Updated Tomcat to 10.1.34

### DIFF
--- a/opensuse-tomcat-jre17-juli-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-jre17-juli-image/src/main/docker/Dockerfile
@@ -27,13 +27,13 @@ ENV TOMCAT_ROOT_DIR $TOMCAT_PARENT_DIR/$TOMCAT_DIR_NAME
 ENV TOMCAT_CONF_DIR $TOMCAT_ROOT_DIR/conf
 
 # Download, extract Tomcat and remove unwanted web applications
-RUN curl -fsSL -o /wd/apache-tomcat-10.1.31.tar.gz https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.31/bin/apache-tomcat-10.1.31.tar.gz && \
-    echo 0e3d423a843e2d9ba4f28a9f0a2f1073d5a1389557dfda041759f8df968bace63cd6948bd76df2727b5133ddb7c33e05dab43cea1d519ca0b6d519461152cce9 \
-        /wd/apache-tomcat-10.1.31.tar.gz | sha512sum -c - && \
+RUN curl -fsSL -o /wd/apache-tomcat-10.1.34.tar.gz https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.34/bin/apache-tomcat-10.1.34.tar.gz && \
+    echo e29c4d0e26295d64dfeee399e7719b5baac2682ac0e7b53702f26d630fea761f93ddf60674dfe87c41ddd9b79d4938a6a533a280bb3d7fb83c2a1b7cd5da6b09 \
+        /wd/apache-tomcat-10.1.34.tar.gz | sha512sum -c - && \
     mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-10.1.31.tar.gz && \
-    mv apache-tomcat-10.1.31 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-10.1.34.tar.gz && \
+    mv apache-tomcat-10.1.34 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf docs/ examples/ host-manager/ manager/
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>com.github.tomcat-slf4j-logback</groupId>
                 <artifactId>tomcat10-slf4j-logback</artifactId>
-                <version>10.1.31</version>
+                <version>10.1.34</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -140,7 +140,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-juli</artifactId>
-                <version>10.1.31</version>
+                <version>10.1.34</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/release-notes-2.6.0.md
+++ b/release-notes-2.6.0.md
@@ -1,1 +1,10 @@
-404: Not Found
+!not-ready-for-release!
+
+#### Version Number
+${version-number}
+
+#### New Features
+
+- Update to Tomcat 10.1.34
+
+#### Known Issues


### PR DESCRIPTION
## Overview

This change mitigates a CVE found in Tomcat 10.1.31 by updating to 10.1.34.

## Reference links

- [CVE-2024-50379 - Red Hat Customer Portal](https://access.redhat.com/security/cve/CVE-2024-50379)
- [CVE-2024-56337 - Red Hat Customer Portal](https://access.redhat.com/security/cve/CVE-2024-56337)
- [CVE-2024-54677 - Red Hat Customer Portal](https://access.redhat.com/security/cve/CVE-2024-54677)
- [CVE-2024-52318 - Red Hat Customer Portal](https://access.redhat.com/security/cve/CVE-2024-52318)